### PR TITLE
Define `objcopy` tool for bootlin toolchains

### DIFF
--- a/toolchain/toolchain_info.bzl
+++ b/toolchain/toolchain_info.bzl
@@ -16,4 +16,14 @@ TOOLCHAIN_INFO = {
     },
 }
 
-ALL_TOOLS = ["ar", "cpp", "gcc", "gcov", "ld", "nm", "objdump", "strip"]
+ALL_TOOLS = [
+    "ar",
+    "cpp",
+    "gcc",
+    "gcov",
+    "ld",
+    "nm",
+    "objcopy",
+    "objdump",
+    "strip",
+]


### PR DESCRIPTION
Bazel 7 requires use of `objcopy` as of this commit: https://github.com/bazelbuild/bazel/commit/2d1f37dd88d4c080e76326831bb234f44f94d263